### PR TITLE
Shape contact against composite shapes fix

### DIFF
--- a/src/query/contact/contact_composite_shape_shape.rs
+++ b/src/query/contact/contact_composite_shape_shape.rs
@@ -55,7 +55,7 @@ where
     G1: ?Sized + CompositeShape,
 {
     CompositeShapeRef(g1)
-        .contact_with_shape(dispatcher, &pose12.inverse(), g2, prediction)
+        .contact_with_shape(dispatcher, &pose12, g2, prediction)
         .map(|c| c.1)
 }
 


### PR DESCRIPTION
Contact checks (for example, shapecasts) between a non-composite shape and a composite shape were often returning invalid results, even when contact was clear; this was caused by an inversion of the vector defining the shapes' relative local positions. 

Note that although composite-shape-on-regular-shape and regular-shape-on-composite-shape checks use separate methods, this extra inversion was triggered in both cases.